### PR TITLE
Cargo.toml: remove "readme" field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "rust-genetic-algorithm"
 version = "1.3.0"
 authors = ["Andrew Schwartzmeyer <andrew@schwartzmeyer.com>"]
 license = "AGPL"
-readme = "README.md"
 repository = "https://github.com/andschwa/rust-genetic-algorithm"
 homepage = "https://github.com/andschwa/rust-genetic-algorithm"
 description = "A genetic algorithm in Rust for Schwefel's function."


### PR DESCRIPTION
It is no more required. See [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field).